### PR TITLE
Update: go 1.22 to go 1.22.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/HugoBlox/hugo-blox-builder/starters/academic-cv
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/HugoBlox/hugo-blox-builder/modules/blox-plugin-netlify v1.1.2-0.20231209203044-d31adfedd40b


### PR DESCRIPTION
Error while building:
 go: download go1.22 for linux/amd64: toolchain not available hugo

Solution:
https://github.com/golang/go/issues/65568